### PR TITLE
Add persistent logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Start capturing screenshots in the background:
 python -m notionlens start
 ```
 
+Logs are written to `~/.notionlens/notionlens.log`.
+
 Configuration is stored in `~/.notionlens/config.json`.
 
 ---

--- a/notionlens/cli.py
+++ b/notionlens/cli.py
@@ -3,7 +3,7 @@ import subprocess
 import sys
 import click
 from pyfiglet import Figlet
-from .config import load_config, save_config
+from .config import load_config, save_config, LOG_PATH, CONFIG_DIR
 from .capture import capture_loop
 
 @click.group()
@@ -28,8 +28,10 @@ def setup():
 def start():
     """Start capturing screenshots as a background process."""
     cmd = [sys.executable, "-m", "notionlens", "capture"]
-    subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, preexec_fn=os.setsid)
-    click.echo("NotionLens started in background")
+    CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    log_handle = open(LOG_PATH, "a")
+    subprocess.Popen(cmd, stdout=log_handle, stderr=log_handle, preexec_fn=os.setsid)
+    click.echo(f"NotionLens started in background. Logs: {LOG_PATH}")
 
 @cli.command(hidden=True)
 def capture():

--- a/notionlens/config.py
+++ b/notionlens/config.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 CONFIG_DIR = Path.home() / ".notionlens"
 CONFIG_PATH = CONFIG_DIR / "config.json"
+LOG_PATH = CONFIG_DIR / "notionlens.log"
 
 DEFAULT_CONFIG = {
     "notion_api_key": "",


### PR DESCRIPTION
## Summary
- add log path constant
- log capture events to the log file
- write stdout/stderr of background process to the log
- document log location

## Testing
- `python -m py_compile notionlens/*.py`
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*
- `python -m notionlens start` *(fails: ModuleNotFoundError: No module named 'pyfiglet')*

------
https://chatgpt.com/codex/tasks/task_e_6846871939888329b042343e4189935d