### PR TITLE
Improve setup by verifying screenshot upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Run the interactive setup:
 ```bash
 python -m notionlens setup
 ```
+The setup now attempts a test screenshot upload. If it fails, you'll be prompted to re-enter your credentials.
 
 Start capturing screenshots in the background:
 

--- a/notionlens/__init__.py
+++ b/notionlens/__init__.py
@@ -1,4 +1,4 @@
 """NotionLens package."""
 
-__all__ = ["cli", "capture_loop"]
+__all__ = ["cli", "capture_loop", "capture_once"]
 

--- a/notionlens/capture.py
+++ b/notionlens/capture.py
@@ -20,63 +20,72 @@ def retry_request(func, retries=3, delay=5):
     return None
 
 
-def capture_loop():
-    cfg = load_config()
-    run_interval = cfg.get("interval", 1)
+def capture_once(cfg=None):
+    """Capture a single screenshot and upload it."""
+    cfg = cfg or load_config()
     notion_api_key = cfg.get("notion_api_key")
     database_id = cfg.get("database_id")
     s3_base_url = cfg.get("s3_upload_url")
 
-    while True:
-        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-        screenshot_filename = f"screenshot_{timestamp}.png"
-        temp_dir = tempfile.gettempdir()
-        screenshot_path = os.path.join(temp_dir, screenshot_filename)
+    timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+    screenshot_filename = f"screenshot_{timestamp}.png"
+    temp_dir = tempfile.gettempdir()
+    screenshot_path = os.path.join(temp_dir, screenshot_filename)
 
-        subprocess.run(["screencapture", "-x", screenshot_path])
-        print(f"Screenshot saved: {screenshot_path}")
+    subprocess.run(["screencapture", "-x", screenshot_path], check=True)
+    print(f"Screenshot saved: {screenshot_path}")
 
-        s3_url = f"{s3_base_url}{screenshot_filename}"
+    s3_url = f"{s3_base_url}{screenshot_filename}"
 
-        def upload_to_s3():
-            with open(screenshot_path, "rb") as file:
-                resp = requests.put(s3_url, data=file, headers={"Content-Type": "image/png"})
-                resp.raise_for_status()
-                print("Uploaded to S3")
-                return True
-
-        def upload_to_notion():
-            headers = {
-                "Authorization": f"Bearer {notion_api_key}",
-                "Content-Type": "application/json",
-                "Notion-Version": "2022-06-28"
-            }
-            payload = {
-                "parent": {"database_id": database_id},
-                "properties": {
-                    "Name": {"title": [{"text": {"content": timestamp}}]},
-                    "Image": {
-                        "files": [
-                            {
-                                "name": "Screenshot",
-                                "type": "external",
-                                "external": {"url": s3_url}
-                            }
-                        ]
-                    }
-                }
-            }
-            resp = requests.post(NOTION_API_URL, headers=headers, json=payload)
+    def upload_to_s3():
+        with open(screenshot_path, "rb") as file:
+            resp = requests.put(s3_url, data=file, headers={"Content-Type": "image/png"})
             resp.raise_for_status()
-            print("Uploaded to Notion")
+            print("Uploaded to S3")
+            return True
 
-        if retry_request(upload_to_s3):
-            retry_request(upload_to_notion)
+    def upload_to_notion():
+        headers = {
+            "Authorization": f"Bearer {notion_api_key}",
+            "Content-Type": "application/json",
+            "Notion-Version": "2022-06-28",
+        }
+        payload = {
+            "parent": {"database_id": database_id},
+            "properties": {
+                "Name": {"title": [{"text": {"content": timestamp}}]},
+                "Image": {
+                    "files": [
+                        {
+                            "name": "Screenshot",
+                            "type": "external",
+                            "external": {"url": s3_url},
+                        }
+                    ]
+                },
+            },
+        }
+        resp = requests.post(NOTION_API_URL, headers=headers, json=payload)
+        resp.raise_for_status()
+        print("Uploaded to Notion")
+        return True
 
+    try:
+        if retry_request(upload_to_s3) and retry_request(upload_to_notion):
+            return True
+        raise RuntimeError("Upload retries exhausted")
+    finally:
         try:
             os.remove(screenshot_path)
         except OSError as e:
             print(f"Could not delete screenshot: {e}")
 
+
+def capture_loop():
+    cfg = load_config()
+    run_interval = cfg.get("interval", 1)
+
+    while True:
+        capture_once(cfg)
         print(f"Waiting {run_interval} minute(s)...\n")
         time.sleep(run_interval * 60)

--- a/notionlens/capture.py
+++ b/notionlens/capture.py
@@ -71,9 +71,16 @@ def capture_once(cfg=None):
         return True
 
     try:
-        if retry_request(upload_to_s3) and retry_request(upload_to_notion):
+        s3_success = retry_request(upload_to_s3)
+        notion_success = retry_request(upload_to_notion)
+        if s3_success and notion_success:
             return True
-        raise RuntimeError("Upload retries exhausted")
+        failed_steps = []
+        if not s3_success:
+            failed_steps.append("S3 upload")
+        if not notion_success:
+            failed_steps.append("Notion upload")
+        raise RuntimeError(f"Upload retries exhausted. Failed steps: {', '.join(failed_steps)}")
     finally:
         try:
             os.remove(screenshot_path)

--- a/notionlens/cli.py
+++ b/notionlens/cli.py
@@ -4,7 +4,7 @@ import sys
 import click
 from pyfiglet import Figlet
 from .config import load_config, save_config
-from .capture import capture_loop
+from .capture import capture_loop, capture_once
 
 @click.group()
 def cli():
@@ -16,13 +16,32 @@ def setup():
     """Interactively set up configuration."""
     fig = Figlet(font="slant")
     click.echo(fig.renderText("NotionLens"))
-    cfg = load_config()
-    cfg["notion_api_key"] = click.prompt("Notion API Key", default=cfg.get("notion_api_key", ""), hide_input=True)
-    cfg["database_id"] = click.prompt("Notion Database ID", default=cfg.get("database_id", ""))
-    cfg["s3_upload_url"] = click.prompt("S3 Upload Base URL", default=cfg.get("s3_upload_url", ""))
-    cfg["interval"] = click.prompt("Capture interval (minutes)", default=cfg.get("interval", 1), type=int)
-    save_config(cfg)
-    click.echo("Configuration saved to ~/.notionlens/config.json")
+
+    while True:
+        cfg = load_config()
+        cfg["notion_api_key"] = click.prompt(
+            "Notion API Key", default=cfg.get("notion_api_key", ""), hide_input=True
+        )
+        cfg["database_id"] = click.prompt(
+            "Notion Database ID", default=cfg.get("database_id", "")
+        )
+        cfg["s3_upload_url"] = click.prompt(
+            "S3 Upload Base URL", default=cfg.get("s3_upload_url", "")
+        )
+        cfg["interval"] = click.prompt(
+            "Capture interval (minutes)", default=cfg.get("interval", 1), type=int
+        )
+        save_config(cfg)
+        click.echo("Configuration saved to ~/.notionlens/config.json")
+
+        try:
+            click.echo("Attempting test upload...")
+            capture_once(cfg)
+            click.echo("Test upload succeeded!")
+            break
+        except Exception as e:
+            click.echo(f"Test upload failed: {e}")
+            click.echo("Please re-enter credentials.\n")
 
 @cli.command()
 def start():


### PR DESCRIPTION
## Summary
- verify user config immediately during setup
- support single-shot screenshot uploads
- document the test upload step

## Testing
- `python -m py_compile notionlens/*.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684687266d78832992bc71b9014744f3