### PR TITLE
Handle missing pyfiglet gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - macOS (uses `screencapture`)
 - A Notion integration (API key + database)
 - An S3 bucket or similar with pre-signed PUT URL support
+- [pyfiglet](https://pypi.org/project/pyfiglet/) (optional, adds ASCII art to the setup command)
 
 ---
 
@@ -33,6 +34,7 @@
 git clone https://github.com/joronadam3/NotionLens.git
 cd NotionLens
 pip install -r requirements.txt
+# 'pyfiglet' is only used for ASCII art in the setup command, so you can skip it if desired
 ```
 
 Run the interactive setup:

--- a/notionlens/cli.py
+++ b/notionlens/cli.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 import click
-from pyfiglet import Figlet
 from .config import load_config, save_config
 from .capture import capture_loop
 
@@ -14,8 +13,12 @@ def cli():
 @cli.command()
 def setup():
     """Interactively set up configuration."""
-    fig = Figlet(font="slant")
-    click.echo(fig.renderText("NotionLens"))
+    try:
+        from pyfiglet import Figlet
+        fig = Figlet(font="slant")
+        click.echo(fig.renderText("NotionLens"))
+    except Exception:
+        pass
     cfg = load_config()
     cfg["notion_api_key"] = click.prompt("Notion API Key", default=cfg.get("notion_api_key", ""), hide_input=True)
     cfg["database_id"] = click.prompt("Notion Database ID", default=cfg.get("database_id", ""))

--- a/notionlens/cli.py
+++ b/notionlens/cli.py
@@ -17,7 +17,7 @@ def setup():
         from pyfiglet import Figlet
         fig = Figlet(font="slant")
         click.echo(fig.renderText("NotionLens"))
-    except Exception:
+    except ImportError:
         pass
     cfg = load_config()
     cfg["notion_api_key"] = click.prompt("Notion API Key", default=cfg.get("notion_api_key", ""), hide_input=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 click
-pyfiglet
+pyfiglet  # optional, only used for ASCII art during setup
 requests


### PR DESCRIPTION
## Summary
- skip Figlet banner if `pyfiglet` is not installed
- mark `pyfiglet` as optional in requirements
- update README about optional dependency

## Testing
- `python -m py_compile notionlens/cli.py`
- `python -m compileall -q .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846874297b48329a7b9feee466157f1