### PR TITLE
Improve status command with error logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,18 +33,34 @@
 git clone https://github.com/joronadam3/NotionLens.git
 cd NotionLens
 pip install -r requirements.txt
+pip install -e .
 ```
 
 Run the interactive setup:
 
 ```bash
-python -m notionlens setup
+notionlens setup
 ```
+
+Command names are all lowercase.
 
 Start capturing screenshots in the background:
 
 ```bash
-python -m notionlens start
+notionlens start
+```
+
+Check the current status and tail the logs. If the process isn't running,
+`notionlens status` also prints the latest error lines from the log file:
+
+```bash
+notionlens status
+```
+
+Stop the background process:
+
+```bash
+notionlens stop
 ```
 
 Logs are written to `~/.notionlens/notionlens.log`.

--- a/notionlens/cli.py
+++ b/notionlens/cli.py
@@ -1,10 +1,23 @@
 import os
 import subprocess
 import sys
+import signal
 import click
 from pyfiglet import Figlet
-from .config import load_config, save_config, LOG_PATH, CONFIG_DIR
+from .config import load_config, save_config, LOG_PATH, CONFIG_DIR, PID_PATH
 from .capture import capture_loop
+
+
+def _get_error_logs(limit: int = 5):
+    """Return the last error lines from the log file."""
+    if not LOG_PATH.exists():
+        return []
+    with open(LOG_PATH, "r", encoding="utf-8") as f:
+        lines = f.readlines()
+    error_lines = [l.strip() for l in lines if "ERROR" in l or "Error" in l or "CRITICAL" in l]
+    if not error_lines:
+        error_lines = [l.strip() for l in lines[-limit:]]
+    return error_lines[-limit:]
 
 @click.group()
 def cli():
@@ -30,8 +43,58 @@ def start():
     cmd = [sys.executable, "-m", "notionlens", "capture"]
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     log_handle = open(LOG_PATH, "a")
-    subprocess.Popen(cmd, stdout=log_handle, stderr=log_handle, preexec_fn=os.setsid)
-    click.echo(f"NotionLens started in background. Logs: {LOG_PATH}")
+    proc = subprocess.Popen(
+        cmd, stdout=log_handle, stderr=log_handle, preexec_fn=os.setsid
+    )
+    PID_PATH.write_text(str(proc.pid))
+    click.echo(
+        f"NotionLens started in background (PID {proc.pid}). Logs: {LOG_PATH}"
+    )
+
+@cli.command()
+def status():
+    """Show status and live logs."""
+    error_logs = _get_error_logs()
+    if PID_PATH.exists():
+        pid = int(PID_PATH.read_text())
+        running = True
+        err_msg = ""
+        try:
+            os.kill(pid, 0)
+        except OSError as e:
+            running = False
+            err_msg = str(e)
+        if running:
+            click.echo(
+                f"NotionLens running (PID {pid}). Showing logs - press Ctrl+C to exit."
+            )
+            subprocess.run(["tail", "-n", "20", "-f", str(LOG_PATH)])
+            return
+        else:
+            click.echo("NotionLens PID file exists but process not running.")
+            if err_msg:
+                click.echo(f"Error: {err_msg}")
+    else:
+        click.echo("NotionLens is not running.")
+
+    if error_logs:
+        click.echo("Last error logs:")
+        for line in error_logs:
+            click.echo(line)
+
+@cli.command()
+def stop():
+    """Stop the background process."""
+    if not PID_PATH.exists():
+        click.echo("NotionLens is not running.")
+        return
+    pid = int(PID_PATH.read_text())
+    try:
+        os.killpg(pid, signal.SIGTERM)
+        click.echo("NotionLens stopped.")
+    except OSError as e:
+        click.echo(f"Error stopping NotionLens: {e}")
+    PID_PATH.unlink(missing_ok=True)
 
 @cli.command(hidden=True)
 def capture():

--- a/notionlens/config.py
+++ b/notionlens/config.py
@@ -5,6 +5,7 @@ from pathlib import Path
 CONFIG_DIR = Path.home() / ".notionlens"
 CONFIG_PATH = CONFIG_DIR / "config.json"
 LOG_PATH = CONFIG_DIR / "notionlens.log"
+PID_PATH = CONFIG_DIR / "notionlens.pid"
 
 DEFAULT_CONFIG = {
     "notion_api_key": "",


### PR DESCRIPTION
## Summary
- show recent error lines when `notionlens status` reports the tool isn't running
- document in README that `status` will print last error logs

## Testing
- `pip install -q -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_68468bfadfe88329ab49c8262e2b6ae4